### PR TITLE
Fixing placeholder and adding in better centering method for the placeholder

### DIFF
--- a/bootstrap-float-label.css
+++ b/bootstrap-float-label.css
@@ -59,9 +59,10 @@
   opacity: 0;
 }
 .has-float-label .form-control:placeholder-shown:not(:focus) + * {
-  font-size: 150%;
+  font-size: 1rem;
   opacity: .5;
   top: .3em;
+  transform: translateY(-50%);
 }
 
 .input-group .has-float-label {


### PR DESCRIPTION
Bootstrap 4's placeholder size is 1rem, not 150%. :)